### PR TITLE
002: ES6 module interop

### DIFF
--- a/000-index.md
+++ b/000-index.md
@@ -1,4 +1,4 @@
 # Node.js Enhancement Proposals
 
 * [Public C++ Streams](001-public-stream-base.md)
-* [ES6 Module Interoperability](./001-es6-modules.md)
+* [ES6 Module Interoperability](./002-es6-modules.md)

--- a/000-index.md
+++ b/000-index.md
@@ -1,3 +1,4 @@
 # Node.js Enhancement Proposals
 
 * [Public C++ Streams](001-public-stream-base.md)
+* [ES6 Module Interoperability](./001-es6-modules.md)

--- a/002-es6-modules.md
+++ b/002-es6-modules.md
@@ -46,6 +46,9 @@ Discusses the syntax and semantics of related syntax, and introduces:
 * [CreateImportBinding](https://tc39.github.io/ecma262/#sec-createimportbinding)
     - A means to create a shared binding (variable) from an export to an import. Required for the "live" binding of imports.
 
+* [ModuleNamespaceCreate](https://tc39.github.io/ecma262/#sec-modulenamespacecreate)
+    - Provides a means of creating a list of exports manually, used so that CommonJS `module.exports` can create ModuleRecords that are prepopulated.
+
 ---
 
 ### [WhatWG Loader](https://github.com/whatwg/loader)
@@ -206,6 +209,9 @@ class Module : Script {
   // 
   // construction via this will act as if it has already been
   // run() and fill out the Namespace()
+  // this in a way mimics:
+  //   1. calling ModuleNamespaceCreate(this, exports)
+  //   2. populating the [[Namespace]] field of this Module Record
   Module(Object exports);
   
   // get a list of imports we need to perform prior to evaluation

--- a/002-es6-modules.md
+++ b/002-es6-modules.md
@@ -7,7 +7,9 @@ Date   | 7 Jan 2016
 
 **NOTE:** `Draft` status means that this has not been accepted for implementation into node core. This is the document of the standard node core would implement a feature should this draft be moved to `Accepted`.
 
-It is our intent to:
+---
+
+The intent of this standard is to:
 
 * implement interoperability for ES modules and node's existing module system
 * create a **Registry Object** (see WHATWG section below) compatible with the WHATWG Loader Registry

--- a/002-es6-modules.md
+++ b/002-es6-modules.md
@@ -114,7 +114,7 @@ Given
 
 ```javascript
 let foo = 'my-default';
-default export foo;
+export default foo;
 ```
 
 ```javascript

--- a/002-es6-modules.md
+++ b/002-es6-modules.md
@@ -149,7 +149,7 @@ will not be supported by the `import` statement. Use local dependencies, and sym
 
 ##### How to support non-local dependencies
 
-Although not recommended, and in fact discouraged, there is a way to support non-local dependencies. **USE THIS AT YOUR OWN DISCRETION*. 
+Although not recommended, and in fact discouraged, there is a way to support non-local dependencies. **USE THIS AT YOUR OWN DISCRETION**. 
 
 Symlinks of `node_modules -> $HOME/.node_modules`, `node_modules/foo/ -> $HOME/.node_modules/foo/`, etc. will continue to be supported.
 

--- a/002-es6-modules.md
+++ b/002-es6-modules.md
@@ -95,7 +95,7 @@ The `.jsm` file extension will have a higher loading priority than `.js`.
 
 ### ES6 Import Resolution
 
-ES6 `import` statements will not perform non-exact searches on relative or absolute paths, unlike `require()`. This means that no file extensions, or index files will be searched for when using relative or absolute paths. `node_modules` based paths will continue to use searching for both compatibility and to not limit the ability to have `package.json` support both ES6 and CJS entry points in a single codebase. `node_modules` based behavior will continue to be unchanged and look to parent `node_modules` directories as well.
+ES6 `import` statements will not perform non-exact searches on relative or absolute paths, unlike `require()`. This means that no file extensions, or index files will be searched for when using relative or absolute paths. `node_modules` based paths will continue to use searching for both compatibility and to not limit the ability to have `package.json` support both ES6 and CJS entry points in a single codebase. `node_modules` based behavior will continue to be unchanged and look to parent `node_modules` directories recursively as well.
 
 In summary:
 

--- a/002-es6-modules.md
+++ b/002-es6-modules.md
@@ -268,40 +268,39 @@ ES6ModuleRegistry.set(__filename, new ModuleStatus({
 }))
 ```
 
-#### Trailer
+#### Immediately Post Evaluation
 
 ```javascript
-;{
-    // module_namespace, how an ES6 module would see a CJS module
-    let module_namespace = Object.create(null);
-    function gatherExports(obj, acc = new Set()) {
-        if (typeof obj !== 'object' && typeof obj !== 'function' || obj === null) {
-            return acc;
-        }
-        for (const key of Object.getOwnPropertyNames(obj)) {
-            const desc = Object.getOwnPropertyDescriptor(obj, key);
-            acc.add({key,desc});
-        }
-        return gatherExports(Object.getPrototypeOf(obj), acc);
+const real_exports = require.cache[__filename].exports;
+// module_namespace, how an ES6 module would see a CJS module
+let module_namespace = Object.create(null);
+function gatherExports(obj, acc = new Set()) {
+    if (typeof obj !== 'object' && typeof obj !== 'function' || obj === null) {
+        return acc;
     }
-    [...gatherExports(real_exports)].forEach(({key,desc}) => {
-        if (key === 'default') return;
-        Object.defineProperty(module_namespace, key, {
-            get: () => real_exports[key],
-            set() {throw new Error(`ModuleNamespace key ${key} is read only.`)},
-            configurable: false,
-            enumerable: Boolean(desc.enumerable)
-        });
-    })
-    Object.defineProperty(module_namespace, 'default', {
-        value: real_exports,
-        writable: false,
-        configurable: false
-    });
-    ES6ModuleRegistry.set(__filename, new ModuleStatus({
-        'ready': {'[[Result]]': module_namespace}
-    });
+    for (const key of Object.getOwnPropertyNames(obj)) {
+        const desc = Object.getOwnPropertyDescriptor(obj, key);
+        acc.add({key,desc});
+    }
+    return gatherExports(Object.getPrototypeOf(obj), acc);
 }
+[...gatherExports(real_exports)].forEach(({key,desc}) => {
+    if (key === 'default') return;
+    Object.defineProperty(module_namespace, key, {
+        get: () => real_exports[key],
+        set() {throw new Error(`ModuleNamespace key ${key} is read only.`)},
+        configurable: false,
+        enumerable: Boolean(desc.enumerable)
+    });
+})
+Object.defineProperty(module_namespace, 'default', {
+    value: real_exports,
+    writable: false,
+    configurable: false
+});
+ES6ModuleRegistry.set(__filename, new ModuleStatus({
+    'ready': {'[[Result]]': module_namespace}
+});
 ```
 
 ### ES6 Modules

--- a/002-es6-modules.md
+++ b/002-es6-modules.md
@@ -94,9 +94,9 @@ This still guarantees:
 
 ### Determining if source is an ES Module
 
-A new filetype will be recognised, `.jsm` as ES modules. They will be treated as a different loading semantic but compatible with existing systems, just like `.node`, `.json`, or usage of `require.extension` (even though deprecated) are compatible. It would be ideal if we could register the filetype with IANA as an offical file type, see [TC39 issue](https://github.com/tc39/ecma262/issues/322). Though it seems this would need to go through the [IESG](https://www.ietf.org/iesg/) and it seems browsers are non-plussed on introducing a new MIME.
+A new filetype will be recognised, `.mjs` as ES modules. They will be treated as a different loading semantic but compatible with existing systems, just like `.node`, `.json`, or usage of `require.extension` (even though deprecated) are compatible. It would be ideal if we could register the filetype with IANA as an offical file type, see [TC39 issue](https://github.com/tc39/ecma262/issues/322). Though it seems this would need to go through the [IESG](https://www.ietf.org/iesg/) and it seems browsers are non-plussed on introducing a new MIME.
 
-The `.jsm` file extension will have a higher loading priority than `.js`.
+The `.mjs` file extension will have a higher loading priority than `.js`.
 
 ### ES Import Path Resolution
 
@@ -185,7 +185,7 @@ This will mean vendored modules are not included in the search path since `packa
 
 #### Shipping both ES and CJS
 
-Since `node_modules` continues to use searching, when a `package.json` main is encountered we are still able to perform file extension searches. If we have 2 entry points `index.jsm` and `index.js` by setting `main:"./index"` we can let Node pick up either depending on what is supported, without us needing to manage multiple entry points separately.
+Since `node_modules` continues to use searching, when a `package.json` main is encountered we are still able to perform file extension searches. If we have 2 entry points `index.mjs` and `index.js` by setting `main:"./index"` we can let Node pick up either depending on what is supported, without us needing to manage multiple entry points separately.
 
 ##### Excluding main
 
@@ -212,7 +212,7 @@ module.exports = {
 You will grab `module.exports` when performing an ES import.
 
 ```javascript
-// es.jsm
+// es.mjs
 
 // grabs the namespace
 import * as baz from './cjs.js';
@@ -242,7 +242,7 @@ module.exports = null;
 You will grab `module.exports` when performing an ES import.
 
 ```javascript
-// es.jsm
+// es.mjs
 import foo from './cjs.js';
 // foo = null;
 
@@ -264,7 +264,7 @@ module.exports = function two() {
 You will grab `module.exports` when performing an ES import.
 
 ```javascript
-// es.jsm
+// es.mjs
 import foo from './cjs.js';
 foo(); // 2
 
@@ -286,7 +286,7 @@ module.exports = Promise.resolve(3);
 You will grab `module.exports` when performing an ES import.
 
 ```javascript
-// es.jsm
+// es.mjs
 import foo from './cjs.js';
 foo.then(console.log); // outputs 3
 
@@ -306,7 +306,7 @@ ES modules only ever declare named exports. A default export just exports a prop
 Given
 
 ```javascript
-// es.jsm
+// es.mjs
 let foo = {bar:'my-default'};
 // note:
 //   this is a value
@@ -332,7 +332,7 @@ console.log(es_namespace.default);
 Given
 
 ```javascript
-// es.jsm
+// es.mjs
 export let foo = {bar:'my-default'};
 export {foo as bar};
 export function f() {};
@@ -433,7 +433,7 @@ require('./es');
 ```
 
 ```javascript
-// es.jsm
+// es.mjs
 import * as ns from './cjs.js';
 // ns = ?
 import cjs from './cjs.js';
@@ -449,7 +449,7 @@ Since this case is coming from ES, we will not break any existing circular depen
 This would change the ES module behavior to:
 
 ```javascript
-// es.jsm
+// es.mjs
 import * as ns from './cjs.js';
 // throw new EvalError('./cjs is not an ES module and has not finished evaluation');
 ```

--- a/002-es6-modules.md
+++ b/002-es6-modules.md
@@ -89,7 +89,9 @@ When `require()`ing a file.
 
 ### Determining if source is an ES6 Module
 
-A new filetype will be recognised, `.jsm` as ES6 based modules. They will be treated as a different loading semantic but compatible with existing systems, just like `.node`, `.json`, or usage of `require.extension` (even though deprecated) are compatible. It would be ideal if we could register the filetype with IANA as an offical file type, see [TC39 issue](https://github.com/tc39/ecma262/issues/322). Though it seems this would need to go through the [IESG](https://www.ietf.org/iesg/) and it seems browsers are non-plussed on introducing a new MIME.
+~~A new filetype will be recognised, `.jsm` as ES6 based modules. They will be treated as a different loading semantic but compatible with existing systems, just like `.node`, `.json`, or usage of `require.extension` (even though deprecated) are compatible. It would be ideal if we could register the filetype with IANA as an offical file type, see [TC39 issue](https://github.com/tc39/ecma262/issues/322). Though it seems this would need to go through the [IESG](https://www.ietf.org/iesg/) and it seems browsers are non-plussed on introducing a new MIME.~~ Both TC39 and WHATWG reject the notion of a new MIME, we would have to push this through without any support from the standards bodies. As such I am for the moment disregarding but keeping reference to this idea.
+
+We will be using a [Directive Prologue](https://tc39.github.io/ecma262/#directive-prologue) in order to detect if source code is ES6. The directive will be `"use module"`.
 
 ### CommonJS consuming ES6
 

--- a/002-es6-modules.md
+++ b/002-es6-modules.md
@@ -95,9 +95,11 @@ The `.jsm` file extension will have a higher loading priority than `.js`.
 
 ### ES6 Import Resolution
 
-ES6 `import` statements will not perform non-exact searches on relative or absolute paths, unlike `require()`. This means that no file extensions, or index files will be searched for when using relative or absolute paths. `node_modules` based paths will continue to use searching for both compatibility and to not limit the ability to have `package.json` support both ES6 and CJS entry points in a single codebase. `node_modules` based behavior will continue to be unchanged and look to parent `node_modules` directories recursively as well.
+ES6 `import` statements will not perform non-exact searches on relative or absolute paths, unlike `require()`. This means that no file extensions, or index files will be searched for when using relative or absolute paths. 
 
-In summary:
+`node_modules` based paths will continue to use searching for both compatibility and to not limit the ability to have `package.json` support both ES6 and CJS entry points in a single codebase. `node_modules` based behavior will continue to be unchanged and look to parent `node_modules` directories recursively as well.
+
+In summary so far:
 
 ```javascript
 // only looks at
@@ -133,6 +135,44 @@ import '/bar';
 //   etc.
 import 'baz';
 ```
+
+#### Removal of non-local dependencies
+
+All of the following:
+
+* `$NODE_PATH`
+* `$HOME/.node_modules`
+* `$HOME/.node_libraries`
+* `$PREFIX/lib/node`
+
+will not be supported by the `import` statement. Use local dependencies, and symbolic links as needed.
+
+##### How to support non-local dependencies
+
+Although not recommended, and in fact discouraged, there is a way to support non-local dependencies. **USE THIS AT YOUR OWN DISCRETION*. 
+
+Symlinks of `node_modules -> $HOME/.node_modules`, `node_modules/foo/ -> $HOME/.node_modules/foo/`, etc. will continue to be supported.
+
+Adding a parent directory with `node_modules` symlinked will be an effective strategy for recreating these functionalities. This will incur the known problems with non-local dependencies, but now leaves the problems in the hands of the user, allowing node to give more clear insight to your modules by reducing complexity.
+
+Given:
+
+```sh
+/opt/local/myapp
+```
+
+Transform to:
+
+```sh
+/opt/local/non-local-deps/myapp
+/opt/local/non-local-deps/node_modules -> $PREFIX/lib/node (etc.)
+```
+
+And nest as many times as needed.
+
+#### Errors
+
+In the case that an `import` statement is unable to find a module, node should make a **best effort** to see if `require` would have found the module and print out where it was found, if `NODE_PATH` was used, if `HOME` was used, etc.
 
 #### Vendored modules
 

--- a/002-es6-modules.md
+++ b/002-es6-modules.md
@@ -319,7 +319,7 @@ fulfillNamespacePromise(module_namespace);
 
 #### Post Parsing
 
-```
+```javascript
 const module = ...;
 const namespacePromise = new Promise((f,r) => {
   fulfillNamespacePromise = f;

--- a/002-es6-modules.md
+++ b/002-es6-modules.md
@@ -299,7 +299,7 @@ class SourceTextModule : Script, Module {
   //
   // this will add the bindings to the lexical environment of
   // the Module
-  ImportDeclarationInstantiation(ImportBinding[] bindings);
+  ModuleDeclarationInstantiation(ImportBinding[] bindings);
 }
 
 class DynamicModule : Module {

--- a/002-es6-modules.md
+++ b/002-es6-modules.md
@@ -118,6 +118,7 @@ The choice of `.mjs` was made due to a number of factors.
     * [small usage on npm](https://gist.github.com/ChALkeR/c10642f2531b1be36e5d)
 * `.mjs`
     * lacks conflicts with other major software, conflicts with [metascript](https://github.com/metascript/metascript) but that was last published in 2014
+    * [small usage on npm](https://gist.github.com/bmeck/07a5beb6541c884acbe908df7b28df3f)
     
 There is knowledge of breakage for code that *upgrades* inner package dependencies such as `require('foo/bar.js')`. As `bar.js` may move to `bar.mjs`. Since `bar.js` is not the listed entry point this was considered ok. If foo was providing this file explicitly like `lodash` has: this can be mitigated easily by using as proxy module should `foo` choose to provide one:
 

--- a/002-es6-modules.md
+++ b/002-es6-modules.md
@@ -243,10 +243,10 @@ You will grab `module.exports` when performing an ES import.
 
 ```javascript
 // es.jsm
-import foo from './cjs';
+import foo from './cjs.js';
 // foo = null;
 
-import * as bar from './cjs';
+import * as bar from './cjs.js';
 // bar = {default:null};
 ```
 
@@ -265,10 +265,10 @@ You will grab `module.exports` when performing an ES import.
 
 ```javascript
 // es.jsm
-import foo from './cjs';
+import foo from './cjs.js';
 foo(); // 2
 
-import * as bar from './cjs';
+import * as bar from './cjs.js';
 bar.name; // 'two'
 bar.default(); // 2
 bar(); // throws, bar is not a function
@@ -287,10 +287,10 @@ You will grab `module.exports` when performing an ES import.
 
 ```javascript
 // es.jsm
-import foo from './cjs';
+import foo from './cjs.js';
 foo.then(console.log); // outputs 3
 
-import * as bar from './cjs';
+import * as bar from './cjs.js';
 bar.default.then(console.log); // outputs 3
 bar.then(console.log); // throws, bar is not a Promise
 ```
@@ -434,9 +434,9 @@ require('./es');
 
 ```javascript
 // es.jsm
-import * as ns from './cjs';
+import * as ns from './cjs.js';
 // ns = ?
-import cjs from './cjs';
+import cjs from './cjs.js';
 // cjs = ?
 ```
 

--- a/002-es6-modules.md
+++ b/002-es6-modules.md
@@ -197,6 +197,8 @@ Since `main` in `package.json` is entirely optional even inside of npm packages,
 
 `module.exports` is a single value. As such it does not have the dictionary like properties of ES module exports. In order to facilitate named imports for ES modules, all properties of `module.exports` will be hoisted to named exports after evaluation of CJS modules with the exception of `default` which will point to `module.exports` directly.
 
+##### Examples
+
 Given:
 
 ```javascript
@@ -216,6 +218,71 @@ import foo from './cjs';
 
 import {default as bar} from './cjs';
 // bar = {default:'my-default', thing:'stuff'};
+```
+
+------
+
+Given:
+
+```javascript
+// cjs.js
+module.exports = null;
+```
+
+You will grab `module.exports` when performing an ES import.
+
+```javascript
+// es.jsm
+import foo from './cjs';
+// foo = null;
+
+import * as bar from './cjs';
+// bar = {default:null};
+```
+
+------
+
+Given:
+
+```javascript
+// cjs.js
+module.exports = function two() {
+  return 2;
+};
+```
+
+You will grab `module.exports` when performing an ES import.
+
+```javascript
+// es.jsm
+import foo from './cjs';
+foo(); // 2
+
+import * as bar from './cjs';
+bar.name; // 'two'
+bar.default(); // 2
+bar(); // throws, bar is not a function
+```
+
+------
+
+Given:
+
+```javascript
+// cjs.js
+module.exports = Promise.resolve(3);
+```
+
+You will grab `module.exports` when performing an ES import.
+
+```javascript
+// es.jsm
+import foo from './cjs';
+foo.then(console.log); // outputs 3
+
+import * as bar from './cjs';
+bar.default.then(console.log); // outputs 3
+bar.then(console.log); // throws, bar is not a Promise
 ```
 
 ### CommonJS consuming ES
@@ -261,15 +328,15 @@ Unlike ES modules, CJS modules have allowed mutation. When ES modules are integr
 Remember that `module.exports` from CJS is directly available under `default` for `import`. This means that if you use:
 
 ```javascript
-import * as shallow from 'grunt';
+import * as namespace from 'grunt';
 ```
 
-According to ES `*` creates a shallow copy and all properties will be read-only.
+According to ES `*` grabs the namespace directly whose properties will be read-only.
 
 However, doing:
 
 ```javascript
-import grunt from 'grunt';
+import grunt_default from 'grunt';
 ```
 
 Grabs the `default` which is exactly what `module.exports` is, and all the properties will be mutable.

--- a/002-es6-modules.md
+++ b/002-es6-modules.md
@@ -322,7 +322,7 @@ Parsing occurs prior to evaluation, and CJS may execute once we start to resolve
 const exports = void 0;
 ```
 
-# Immediately Post Evaluation
+#### Immediately Post Evaluation
 
 ```javascript
 const module_namespace = ES6ModuleRegistry.get(__filename).GetStage('ready')['[[result]]'];

--- a/002-es6-modules.md
+++ b/002-es6-modules.md
@@ -89,7 +89,7 @@ When `require()`ing a file.
 
 ### Determining if source is an ES6 Module
 
-A new filetype will be recognised, `.es` as ES6 based modules. They will be treated as a different loading semantic but compatible with existing systems, just like `.node`, `.json`, or usage of `require.extension` (even though deprecated) are compatible.
+A new filetype will be recognised, `.jsm` as ES6 based modules. They will be treated as a different loading semantic but compatible with existing systems, just like `.node`, `.json`, or usage of `require.extension` (even though deprecated) are compatible.
 
 ### CommonJS consuming ES6
 

--- a/002-es6-modules.md
+++ b/002-es6-modules.md
@@ -8,7 +8,7 @@ Date   | 7 Jan 2016
 It is our intent to:
 
 * implement interoperability for ES6 modules and node's existing module system
-* create a **Registry Object** (see WhatWG section below) compatible with the WhatWG Loader Registry
+* create a **Registry Object** (see WHATWG section below) compatible with the WHATWG Loader Registry
 
 ## Purpose
 
@@ -51,7 +51,7 @@ Discusses the syntax and semantics of related syntax, and introduces:
 
 ---
 
-### [WhatWG Loader](https://github.com/whatwg/loader)
+### [WHATWG Loader](https://github.com/whatwg/loader)
 
 ---
 

--- a/002-es6-modules.md
+++ b/002-es6-modules.md
@@ -14,7 +14,7 @@ It is our intent to:
 
 1. Allow a common module syntax for Browser and Server.
 2. Allow a common registry for inspection by Browser and Server environments/tools.
-    * these will most likely be represented by metaproperties like `import.ctx` but spec is not in place fully yet.
+    * these will most likely be represented by metaproperties like `import.context` but spec is not in place fully yet.
 
 ## Related
 

--- a/002-es6-modules.md
+++ b/002-es6-modules.md
@@ -66,6 +66,25 @@ Discusses the design of module metadata in a [Registry](https://whatwg.github.io
 
 ### DynamicModuleRecord
 
+A Module Record that presents a view of an Object for its `[[Namespace]]` rather than coming from an environment record.
+
+The list of exports is frozen upon construction. No new properties may be added. No properties may be removed.
+
+## Algorithm
+
+When `require()`ing a file.
+
+1. Determine if file is ES6 or CommonJS (CJS).
+2. If CJS
+	1. Evaluate immediately
+	2. Produce a DynamicModuleRecord from `module.exports`
+3. If ES6
+	1. Parse for `import`/`export`s and keep record, in order to create bindings
+	2. Gather all submodules by performing `require` recursively
+		* See circular dep semantics below 
+	3. Connect `import` bindings for all relevant submodules (see [ModuleDeclarationInstantiation](https://tc39.github.io/ecma262/#sec-moduledeclarationinstantiation))
+	4. Evaluate
+
 ## Semantics
 
 ### Determining if source is an ES6 Module

--- a/002-es6-modules.md
+++ b/002-es6-modules.md
@@ -285,13 +285,13 @@ ES6ModuleRegistry.set(__filename, new ModuleStatus({
         return gatherExports(Object.getPrototypeOf(obj), acc);
     }
     [...gatherExports(real_exports)].forEach(({key,desc}) => {
-    if (key === 'default') return;
-    Object.defineProperty(module_namespace, key, {
-        get: () => real_exports[key],
-        set() {throw new Error(`ModuleNamespace key ${key} is read only.`)},
-        configurable: false,
-        enumerable: Boolean(desc.enumerable)
-    });
+        if (key === 'default') return;
+        Object.defineProperty(module_namespace, key, {
+            get: () => real_exports[key],
+            set() {throw new Error(`ModuleNamespace key ${key} is read only.`)},
+            configurable: false,
+            enumerable: Boolean(desc.enumerable)
+        });
     })
     Object.defineProperty(module_namespace, 'default', {
         value: real_exports,

--- a/002-es6-modules.md
+++ b/002-es6-modules.md
@@ -139,7 +139,6 @@ There were proposals of using `package.json` as an out of band configuration as 
 * removes one-off file execution for quick scripting like using `.save` in the repl then running.
 * causes editors/asset pipelines to have knowledge of this. most work solely on file extension and it would be prohibitive to change.
     * Build asset pipelines in particular would be affected such as the Rails asset pipeline
-    * OS file associations could be complicated since they work after the last `.`
     * HTTP/2 PUSH solutions would also need this and would be affected
 * no direction for complete removal of CJS. A file extension leads to a world without `.js` and only `.mjs` files. This would be a permanent field in `package.json`
 * per file mode requirements mean using globs or large lists

--- a/002-es6-modules.md
+++ b/002-es6-modules.md
@@ -89,7 +89,7 @@ When `require()`ing a file.
 
 ### Determining if source is an ES6 Module
 
-A new filetype will be recognised, `.jsm` as ES6 based modules. They will be treated as a different loading semantic but compatible with existing systems, just like `.node`, `.json`, or usage of `require.extension` (even though deprecated) are compatible.
+A new filetype will be recognised, `.jsm` as ES6 based modules. They will be treated as a different loading semantic but compatible with existing systems, just like `.node`, `.json`, or usage of `require.extension` (even though deprecated) are compatible. It would be ideal if we could register the filetype with IANA as an offical file type, see [TC39 issue](https://github.com/tc39/ecma262/issues/322). Though it seems this would need to go through the [IESG](https://www.ietf.org/iesg/) and it seems browsers are non-plussed on introducing a new MIME.
 
 ### CommonJS consuming ES6
 

--- a/002-es6-modules.md
+++ b/002-es6-modules.md
@@ -236,7 +236,7 @@ class SourceTextModule : Script, Module {
   //
   // this will add the bindings to the lexical environment of
   // the Module
-  FillImports(ImportBinding[] bindings);
+  ImportDeclarationInstantiation(ImportBinding[] bindings);
 }
 
 class DynamicModule : Module {
@@ -244,7 +244,7 @@ class DynamicModule : Module {
   // ES6 Module compatibility we need to hook up a static
   // View of an Object to set as our exports
   //
-  // think of this as calling FillImports using the current
+  // think of this as calling ImportDeclarationInstantiation using the current
   // properties of an object, enumerable or not.
   //
   // exports are never added or removed from the Module even

--- a/002-es6-modules.md
+++ b/002-es6-modules.md
@@ -89,20 +89,7 @@ When `require()`ing a file.
 
 ### Determining if source is an ES6 Module
 
-If a module can be parsed outside of the ES6 Module goal, it will be treated as a [Script](https://tc39.github.io/ecma262/#sec-parse-script). Otherwise it will be parsed as [ES6](https://tc39.github.io/ecma262/#sec-parsemodule).
-
-In pseudocode, it looks somewhat like:
-
-```
-try {
-  v8::Script::Compile
-}
-catch (e) {
-  v8::Script::CompileModule
-}
-```
-
-V8 may or may not choose to use parser fallback to combine this into one step.
+A new filetype will be recognised, `.es` as ES6 based modules. They will be treated as a different loading semantic but compatible with existing systems, just like `.node`, `.json`, or usage of `require.extension` (even though deprecated) are compatible.
 
 ### CommonJS consuming ES6
 
@@ -200,22 +187,10 @@ V8 currently does not expose the proper APIs for creating Loaders, it has done t
 
 It has been recommended that we list a potential API we could consume in order to create our loader. These extensions are listed below.
 
-### Double Parsing Problem
-
-Due to the fact that we are going to be performing detection of grammar goal using parse failure or the presense of `import`/`export`. It would be ideal if `Compile` and `CompileModule` where merged into a single call. Assuming such we will place our additions in the `CompileOptions` and `Script` types. If such change is not possible, we will be using the fallback method listed in this proposal above.
-
 ### API Suggestion
 
 ```c++
-namespace v8
-
-CompileOptions {
-  // parse to Script or Module based upon invalid syntax
-  // default is Module
-  kDetectGoal
-  // tells the parser to change the detect goal default to Script
-  kDefaultGoalScript
-};
+namespace v8;
 
 class Module {
   // return a ModuleNamespace view of this Module's exports

--- a/002-es6-modules.md
+++ b/002-es6-modules.md
@@ -5,6 +5,8 @@ Status | Draft
 Author | Bradley Meck
 Date   | 7 Jan 2016
 
+**NOTE:** `Draft` status means that this has not been accepted for implementation into node core. This is the document of the standard node core would implement a feature should this draft be moved to `Accepted`.
+
 It is our intent to:
 
 * implement interoperability for ES modules and node's existing module system

--- a/002-es6-modules.md
+++ b/002-es6-modules.md
@@ -275,14 +275,14 @@ ES6ModuleRegistry.set(__filename, new ModuleStatus({
     // module_namespace, how an ES6 module would see a CJS module
     let module_namespace = Object.create(null);
     function gatherExports(obj, acc = new Set()) {
-    if (typeof obj !== 'object' && typeof obj !== 'function' || obj === null) {
-        return acc;
-    }
-    for (const key of Object.getOwnPropertyNames(obj)) {
-        const desc = Object.getOwnPropertyDescriptor(obj, key);
-        acc.add({key,desc});
-    }
-    return gatherExports(Object.getPrototypeOf(obj), acc);
+        if (typeof obj !== 'object' && typeof obj !== 'function' || obj === null) {
+            return acc;
+        }
+        for (const key of Object.getOwnPropertyNames(obj)) {
+            const desc = Object.getOwnPropertyDescriptor(obj, key);
+            acc.add({key,desc});
+        }
+        return gatherExports(Object.getPrototypeOf(obj), acc);
     }
     [...gatherExports(real_exports)].forEach(({key,desc}) => {
     if (key === 'default') return;
@@ -294,9 +294,9 @@ ES6ModuleRegistry.set(__filename, new ModuleStatus({
     });
     })
     Object.defineProperty(module_namespace, 'default', {
-    value: real_exports,
-    writable: false,
-    configurable: false
+        value: real_exports,
+        writable: false,
+        configurable: false
     });
     ES6ModuleRegistry.set(__filename, new ModuleStatus({
         'ready': {'[[Result]]': module_namespace}

--- a/002-es6-modules.md
+++ b/002-es6-modules.md
@@ -215,18 +215,18 @@ You will grab `module.exports` when performing an ES import.
 // es.jsm
 
 // grabs the namespace
-import * as baz from './cjs';
+import * as baz from './cjs.js';
 // baz = {
 //   get default() {return module.exports;},
 //   get thing() {return this.default.thing}.bind(baz)
 // }
 
 // grabs "default", aka module.exports directly
-import foo from './cjs';
+import foo from './cjs.js';
 // foo = {default:'my-default', thing:'stuff'};
 
 // grabs "default", aka module.exports directly
-import {default as bar} from './cjs';
+import {default as bar} from './cjs.js';
 // bar = {default:'my-default', thing:'stuff'};
 ```
 
@@ -450,7 +450,7 @@ This would change the ES module behavior to:
 
 ```javascript
 // es.jsm
-import * as ns from './cjs';
+import * as ns from './cjs.js';
 // throw new EvalError('./cjs is not an ES module and has not finished evaluation');
 ```
 

--- a/002-es6-modules.md
+++ b/002-es6-modules.md
@@ -95,7 +95,7 @@ The `.jsm` file extension will have a higher loading priority than `.js`.
 
 ### ES6 Import Resolution
 
-ES6 `import` statements will not perform non-exact searches on relative or absolute paths, unlike `require()`. This means that no file extensions, or index files will be searched for when using relative or absolute paths. `node_modules` based paths will continue to use searching for both compatibility and to not limit the ability to have `package.json` support both ES6 and CJS entry points in a single codebase.
+ES6 `import` statements will not perform non-exact searches on relative or absolute paths, unlike `require()`. This means that no file extensions, or index files will be searched for when using relative or absolute paths. `node_modules` based paths will continue to use searching for both compatibility and to not limit the ability to have `package.json` support both ES6 and CJS entry points in a single codebase. `node_modules` based behavior will continue to be unchanged and look to parent `node_modules` directories as well.
 
 In summary:
 
@@ -123,9 +123,14 @@ import '/bar';
 
 ```javascript
 // continues to *search*:
-//   node_modules/baz.js
-//   node_modules/baz/package.json
-//   node_modules/baz/index.js
+//   ./node_modules/baz.js
+//   ./node_modules/baz/package.json
+//   ./node_modules/baz/index.js
+// and parent node_modules:
+//   ../node_modules/baz.js
+//   ../node_modules/baz/package.json
+//   ../node_modules/baz/index.js
+//   etc.
 import 'baz';
 ```
 

--- a/002-es6-modules.md
+++ b/002-es6-modules.md
@@ -196,7 +196,7 @@ export default foo;
 ```
 
 ```javascript
-const foo = require('./es6').foo;
+const foo = require('./es6').default;
 ```
 
 #### read only

--- a/002-es6-modules.md
+++ b/002-es6-modules.md
@@ -33,7 +33,7 @@ Discusses the syntax and semantics of related syntax, and introduces:
     - Defines the list of exports via [ExportEntry](https://tc39.github.io/ecma262/#table-41).
     
 * [ModuleNamespace](https://tc39.github.io/ecma262/#sec-module-namespace-exotic-objects)
-    - Represents a read-only snapshot of a module's exports.
+    - Represents a read-only static set of live bindings of a module's exports.
     
 ### Operations
     


### PR DESCRIPTION
Issue links for subtopics:
- [ES Module Detection](https://github.com/nodejs/node-eps/issues/13)
- [Module Evaluation Ordering](https://github.com/nodejs/node-eps/issues/12)
- [ES Module Path Resolution](https://github.com/nodejs/node-eps/issues/11)
- [CJS <-> ES import/export Conversion](https://github.com/nodejs/node-eps/issues/10)
