### PR TITLE
002 - Clarify asset pipeline concern

### DIFF
--- a/002-es6-modules.md
+++ b/002-es6-modules.md
@@ -283,8 +283,6 @@ well.
   repl then running.
 * causes editors/asset pipelines to have knowledge of this. most work solely on
   file extension and it would be prohibitive to change.
-    * Build asset pipelines in particular would be affected such as the Rails
-      asset pipeline
     * HTTP/2 PUSH solutions would also need this and would be affected
 * no direction for complete removal of CJS. A file extension leads to a world
   without `.js` and only `.mjs` files. This would be a permanent field in


### PR DESCRIPTION
Per the discussion in #24, the asset pipeline concern raised by @ljharb was related to the required-parsing solution, not the `package.json` solution.

Clarify by removing it as a concern from that section.
