### PR TITLE
Editorial fixes / suggestions for ES6 Module Interoperability

### DIFF
--- a/002-es6-modules.md
+++ b/002-es6-modules.md
@@ -548,7 +548,7 @@ No existing code will be affected.
 
 #### 5.6.1. ES exports are read only
 
-The objects create by an ES module are [ModuleNamespace Objects][5].
+The objects created by an ES module are [ModuleNamespace Objects][5].
 
 These have `[[Set]]` be a no-op and are read only views of the exports of an ES
 module. Attempting to reassign any named export will not work, but assigning to

--- a/002-es6-modules.md
+++ b/002-es6-modules.md
@@ -37,7 +37,7 @@ related syntax, and introduces:
     - Defines the list of imports via `[[ImportEntry]]`.
     - Defines the list of exports via `[[ExportEntry]]`.
 
-* **[ModuleNamespace]
+* **[Module Namespace]
 (https://tc39.github.io/ecma262/#sec-module-namespace-objects)**
     - Represents a read-only static set of bindings to a module's exports.
 
@@ -111,7 +111,7 @@ steps:
 
 ### 3.2. **DelegatedModuleNamespaceObject**
 
-A `ModuleNamespaceObject` that performs delegation to an Object when accessing
+A Module Namespace Object that performs delegation to an Object when accessing
 properties. This is used for delegation behavior from CJS `module.exports` when
 imported by ES modules.
 
@@ -548,7 +548,7 @@ No existing code will be affected.
 
 #### 5.6.1. ES exports are read only
 
-When CommonJS consumes ES, `require()` returns a [ModuleNamespace Object](https://tc39.github.io/ecma262/#sec-module-namespace-objects). These have a no-op `[[Set]]` that makes them read only views of the exports of an ES module. Attempting to assign to any property of the Module Namespace Object will not work, but assignment to properties of exported objects follows normal rules. Example:
+When CommonJS consumes ES, `require()` returns a [Module Namespace Object](https://tc39.github.io/ecma262/#sec-module-namespace-objects). These have a no-op `[[Set]]` that makes them read only views of the exports of an ES module. Attempting to assign to any property of the Module Namespace Object will not work, but assignment to properties of exported objects follows normal rules. Example:
 
 ```javascript
 const es_namespace = require('./es');
@@ -671,7 +671,7 @@ import * as ns from './cjs.js';
 
 These are written with the expectation that:
 
-* ModuleNamespaces can be created from existing Objects.
+* Module Namespace Objects can be created from existing Objects.
 * WHATWG Loader spec Registry is available as a ModuleRegistry.
 * ModuleStatus Objects can be created.
 

--- a/002-es6-modules.md
+++ b/002-es6-modules.md
@@ -548,7 +548,17 @@ No existing code will be affected.
 
 #### 5.6.1. ES exports are read only
 
-When CommonJS consumes ES, `require()` returns a [ModuleNamespace Object](https://tc39.github.io/ecma262/#sec-module-namespace-objects). These have a no-op `[[Set]]` that makes them read only views of the exports of an ES module. Attempting to assign to any property of the Module Namespace Object will not work, but assignment to properties of exported objects follows normal rules.
+When CommonJS consumes ES, `require()` returns a [ModuleNamespace Object](https://tc39.github.io/ecma262/#sec-module-namespace-objects). These have a no-op `[[Set]]` that makes them read only views of the exports of an ES module. Attempting to assign to any property of the Module Namespace Object will not work, but assignment to properties of exported objects follows normal rules. Example:
+
+```javascript
+const es_namespace = require('./es');
+
+// Doesn't work:
+es_namespace.foo = {};
+
+// Normal rules:
+es_namespace.foo.bar = {};
+```
 
 ### 5.7. CJS modules allow mutation of imported modules
 

--- a/002-es6-modules.md
+++ b/002-es6-modules.md
@@ -548,7 +548,7 @@ No existing code will be affected.
 
 #### 5.6.1. ES exports are read only
 
-The objects created by an ES module are [ModuleNamespace Objects][5].
+The objects created by an ES module are [ModuleNamespace Objects](https://tc39.github.io/ecma262/#sec-module-namespace-objects).
 
 These have `[[Set]]` be a no-op and are read only views of the exports of an ES
 module. Attempting to reassign any named export will not work, but assigning to

--- a/002-es6-modules.md
+++ b/002-es6-modules.md
@@ -619,8 +619,8 @@ console.log(namespace.foo); // undefined
 
 // mutate to show 'yo' still exists as a binding
 import cjs_exports from './bad-cjs.js';
-cjs_exports.yo = 'lo again';
-console.log(namespace.yo); // 'yolo again'
+cjs_exports.yo += ' again';
+console.log(namespace.yo); // 'lo again'
 ```
 
 #### 5.7.3. Circular Dep CJS => ES => CJS Causes Throw

--- a/002-es6-modules.md
+++ b/002-es6-modules.md
@@ -548,11 +548,7 @@ No existing code will be affected.
 
 #### 5.6.1. ES exports are read only
 
-The objects created by an ES module are [ModuleNamespace Objects](https://tc39.github.io/ecma262/#sec-module-namespace-objects).
-
-These have `[[Set]]` be a no-op and are read only views of the exports of an ES
-module. Attempting to reassign any named export will not work, but assigning to
-the properties of the exports follows normal rules.
+When CommonJS consumes ES, `require()` returns a [ModuleNamespace Object](https://tc39.github.io/ecma262/#sec-module-namespace-objects). These have a no-op `[[Set]]` that makes them read only views of the exports of an ES module. Attempting to assign to any property of the Module Namespace Object will not work, but assignment to properties of exported objects follows normal rules.
 
 ### 5.7. CJS modules allow mutation of imported modules
 


### PR DESCRIPTION
Separate commits to make it easier to consider the changes individually.

56faad9f182df68e8c25ee86196100e7b414e155
Some of the changes are subjective style suggestions, but I think the _named export_ language here could be confusing in terms of ability to reassign the value of a binding inside the module that exports it:

> Attempting to reassign any named export will not work

Properties of namespace objects are live bindings, right?

f753479ec1856e347b7ff9dbcbe110ef37b9f139
Style nit. The formatting _ModuleNamespace_ or _ModuleNamespaceObject_ doesn't seem to appear in the spec. It seems to always be _Module Namespace [Exotic] Object_ (though sometimes it's lowercase and sometimes title case).

If you don't like the style changes, ¯\_(ツ)_/¯, but hopefully you find the other stuff worthwhile.
