### PR TITLE
Fix typo in es6 modules proposal

### DIFF
--- a/002-es6-modules.md
+++ b/002-es6-modules.md
@@ -457,8 +457,8 @@ import foo from './cjs.js';
 foo(); // 2
 
 import * as bar from './cjs.js';
-bar.name; // 'two'
 bar.default(); // 2
+bar.name; // undefined
 bar(); // throws, bar is not a function
 ```
 


### PR DESCRIPTION
Hi,

I may be understanding the proposal wrong, in which case please close this PR.

If I'm understanding it correctly, though, I'd expect `import * as bar from './cjs.js';` to be a ModuleNamespaceObject rather than the `module.exports` function value, so name would be undefined. Right?
